### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,5 +78,5 @@ pub fn executar_estatisticas_descritivas(numeros: Vec<i32>){
     println!("Media: {:.2}", media_resultado);
 
     let moda_resultado = estatisticas.moda();
-    println!("Moda: {:.?}", moda_resultado);
+    println!("Moda: {:?}", moda_resultado);
 }


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See rust-lang/rust#131159 and rust-lang/rust#136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.